### PR TITLE
Easy way out making tabs wider and text shorter

### DIFF
--- a/content/jobs/Motivate/index.md
+++ b/content/jobs/Motivate/index.md
@@ -1,7 +1,7 @@
 ---
 date: '2016-08-01'
 title: 'Web Developer'
-company: 'Alta Bicycle Share/Motivate/Lyft'
+company: 'Alta Bicycle Share'
 location: 'Portland, OR'
 range: 'March 2012 – August 2016'
 url: 'https://www.motivateco.com/'

--- a/src/components/sections/jobs.js
+++ b/src/components/sections/jobs.js
@@ -80,11 +80,11 @@ const StyledTabButton = styled.button`
     text-align: center;
     border-left: 0;
     border-bottom: 2px solid ${colors.lightestNavy};
-    min-width: 120px;
+    min-width: 175px;
   `};
   &:hover {
     background-color: ${colors.lightNavy};
-  }
+  };
 `;
 const StyledHighlight = styled.span`
   display: block;

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -49,7 +49,7 @@ const theme = {
   margin: '20px',
 
   tabHeight: 42,
-  tabWidth: 120,
+  tabWidth: 175,
   radius: 3,
 
   hamburgerWidth: 30,


### PR DESCRIPTION
This is so the animated highlight will have the correct width and placement on mobile devices.